### PR TITLE
Use Serializer in autoconfigured EventStorageEngine

### DIFF
--- a/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/AxonAutoConfiguration.java
+++ b/spring-boot-autoconfigure/src/main/java/org/axonframework/boot/AxonAutoConfiguration.java
@@ -169,8 +169,8 @@ public class AxonAutoConfiguration {
         @ConditionalOnMissingBean
         @Bean
         public EventStorageEngine eventStorageEngine(EntityManagerProvider entityManagerProvider,
-                                                     TransactionManager transactionManager) {
-            return new JpaEventStorageEngine(entityManagerProvider, transactionManager);
+                                                     TransactionManager transactionManager, Serializer serializer) {
+            return new JpaEventStorageEngine(serializer, null, null, null, entityManagerProvider, transactionManager, null, null, true);
         }
 
         @ConditionalOnMissingBean

--- a/spring-boot-autoconfigure/src/test/java/org/axonframework/boot/AxonAutoConfigurationWithHibernateTest.java
+++ b/spring-boot-autoconfigure/src/test/java/org/axonframework/boot/AxonAutoConfigurationWithHibernateTest.java
@@ -48,4 +48,12 @@ public class AxonAutoConfigurationWithHibernateTest {
 
         assertEquals(5, entityManager.getEntityManagerFactory().getMetamodel().getEntities().size());
     }
+
+    @Test
+    public void testEventStorageEngingeUsesSerializerBean() {
+        final Serializer serializer = applicationContext.getBean(Serializer.class);
+        final JpaEventStorageEngine engine = applicationContext.getBean(JpaEventStorageEngine.class);
+
+        assertEquals(serializer, engine.getSerializer());
+    }
 }


### PR DESCRIPTION
The JpaEventStorageEngine now uses the seriallizer bean .

See #282